### PR TITLE
migrate to deno v0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ const ui8 = await writePngDpi(buf, dpi)
 ## Examples
 ### Reader
 ```
-$ deno ./examples/reader.ts ./examples/retina/7127a0c2a987ea50dbba0ebd6455c206.png
+$ deno ./examples/reader.ts --allow-read ./examples/retina/7127a0c2a987ea50dbba0ebd6455c206.png
 $ deno https://denopkg.com/daiiz/deno-png-dpi-reader/examples/reader.ts --allow-net https://i.gyazo.com/7127a0c2a987ea50dbba0ebd6455c206.png
 ```
 
@@ -29,5 +29,5 @@ Result:
 
 ### Writer
 ```
-$ deno ./examples/writer.ts ./examples/non-retina/button.png 72 > a.png
+$ deno ./examples/writer.ts --allow-read ./examples/non-retina/8d132d64902c1323ffa8ca688b2c40eb.png 72 > a.png
 ```

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ A [deno](https://github.com/denoland/deno) port of [png-dpi-reader-writer](https
 Detect width, height and DPI for PNG image.
 ```ts
 // buf: deno/Buffer
-const {width, height, dpi} = await parsePngFormat(buf)
+const { width, height, dpi } = await parsePngFormat(buf)
 ```
 
 Write DPI for PNG image.
 ```ts
-const ui8 = await writePngDpi(buf, dpi)
+const ui8arr = await writePngDpi(buf, dpi)
 ```
 
 ## Examples

--- a/examples/reader.ts
+++ b/examples/reader.ts
@@ -1,5 +1,5 @@
-import {loadLocalImage, fetchImage} from './share.ts'
-import {parsePngFormat} from '../mod.ts'
+import { loadLocalImage, fetchImage } from './share.ts'
+import { parsePngFormat } from '../mod.ts'
 const { args } = Deno
 
 const main = async () => {
@@ -16,4 +16,3 @@ const main = async () => {
 }
 
 main()
-

--- a/examples/reader.ts
+++ b/examples/reader.ts
@@ -1,12 +1,12 @@
-import {args, Buffer} from 'deno'
 import {loadLocalImage, fetchImage} from './share.ts'
 import {parsePngFormat} from '../mod.ts'
+const { args } = Deno
 
 const main = async () => {
   if (!args[1]) throw new Error('image url is required.')
 
   const srcUrl = args[1]
-  let buf: Buffer
+  let buf: Deno.Buffer
   if (!/https?:\/\//.test(srcUrl)) {
     buf = await loadLocalImage(srcUrl)
   } else {

--- a/examples/share.ts
+++ b/examples/share.ts
@@ -1,6 +1,6 @@
-import {open, copy, Buffer} from 'deno'
+const { open, copy, Buffer } = Deno
 
-export const loadLocalImage = async (srcPath): Promise<Buffer> => {
+export const loadLocalImage = async (srcPath): Promise<Deno.Buffer> => {
   const imgFile = await open(srcPath)
   // https://github.com/denoland/deno/blob/master/js/buffer.ts
   const buf = new Buffer()
@@ -8,7 +8,7 @@ export const loadLocalImage = async (srcPath): Promise<Buffer> => {
   return buf // Buffer {off: 0, buf: []}
 }
 
-export const fetchImage = async (srcUrl): Promise<Buffer> => {
+export const fetchImage = async (srcUrl): Promise<Deno.Buffer> => {
   // https://github.com/denoland/deno/blob/master/js/fetch.ts
   const res = await fetch(srcUrl)
   const buf = new Buffer(await res.arrayBuffer())

--- a/examples/share.ts
+++ b/examples/share.ts
@@ -5,7 +5,7 @@ export const loadLocalImage = async (srcPath): Promise<Deno.Buffer> => {
   // https://github.com/denoland/deno/blob/master/js/buffer.ts
   const buf = new Buffer()
   await copy(buf, imgFile)
-  return buf // Buffer {off: 0, buf: []}
+  return buf // Buffer { off: 0, buf: [] }
 }
 
 export const fetchImage = async (srcUrl): Promise<Deno.Buffer> => {

--- a/examples/writer.ts
+++ b/examples/writer.ts
@@ -1,6 +1,6 @@
-import {args, Buffer, stdout} from 'deno'
 import {loadLocalImage, fetchImage} from './share.ts'
 import {writePngDpi} from '../mod.ts'
+const { args, Buffer, stdout } = Deno
 
 const main = async () => {
   if (!args[1]) throw new Error('image url is required.')
@@ -9,7 +9,7 @@ const main = async () => {
   const srcUrl = args[1]
   const dpi = +args[2]
 
-  let buf: Buffer
+  let buf: Deno.Buffer
   if (!/https?:\/\//.test(srcUrl)) {
     buf = await loadLocalImage(srcUrl)
   } else {

--- a/examples/writer.ts
+++ b/examples/writer.ts
@@ -1,6 +1,6 @@
-import {loadLocalImage, fetchImage} from './share.ts'
-import {writePngDpi} from '../mod.ts'
-const { args, Buffer, stdout } = Deno
+import { loadLocalImage, fetchImage } from './share.ts'
+import { writePngDpi } from '../mod.ts'
+const { args, stdout } = Deno
 
 const main = async () => {
   if (!args[1]) throw new Error('image url is required.')

--- a/mod.ts
+++ b/mod.ts
@@ -1,2 +1,2 @@
-export {parsePngFormat} from './reader.ts'
-export {writePngDpi} from './writer.ts'
+export { parsePngFormat } from './reader.ts'
+export { writePngDpi } from './writer.ts'

--- a/reader.ts
+++ b/reader.ts
@@ -1,11 +1,11 @@
-import {Buffer} from 'deno'
 import {isPng, toDec, readIHDR, getCharCodes, ImageInfo} from './share.ts'
+const { Buffer } = Deno
 
-export async function parsePngFormat (buf: Buffer): Promise<ImageInfo> {
+export async function parsePngFormat(buf: Deno.Buffer): Promise<ImageInfo> {
   return readChunks(buf)
 }
 
-const readpHYs = async (buf: Buffer): Promise<number> => {
+const readpHYs = async (buf: Deno.Buffer): Promise<number> => {
   let p
   // https://tools.ietf.org/html/rfc2083#page-22
   p = new Uint8Array(4); await buf.read(p)
@@ -23,7 +23,7 @@ const readpHYs = async (buf: Buffer): Promise<number> => {
   return dpi
 }
 
-const readChunks = async (buf: Buffer): Promise<ImageInfo> => {
+const readChunks = async (buf: Deno.Buffer): Promise<ImageInfo> => {
   let info: ImageInfo = {}
   if (!await isPng(buf)) return info
   const {width, height} = await readIHDR(buf)

--- a/reader.ts
+++ b/reader.ts
@@ -1,5 +1,4 @@
-import {isPng, toDec, readIHDR, getCharCodes, ImageInfo} from './share.ts'
-const { Buffer } = Deno
+import { isPng, toDec, readIHDR, getCharCodes, ImageInfo } from './share.ts'
 
 export async function parsePngFormat(buf: Deno.Buffer): Promise<ImageInfo> {
   return readChunks(buf)
@@ -26,7 +25,7 @@ const readpHYs = async (buf: Deno.Buffer): Promise<number> => {
 const readChunks = async (buf: Deno.Buffer): Promise<ImageInfo> => {
   let info: ImageInfo = {}
   if (!await isPng(buf)) return info
-  const {width, height} = await readIHDR(buf)
+  const { width, height } = await readIHDR(buf)
   info.width = width
   info.height = height
 

--- a/share.ts
+++ b/share.ts
@@ -1,4 +1,4 @@
-import {Buffer} from 'deno'
+const { Buffer } = Deno
 
 export interface ImageInfo {
   width?: number,
@@ -11,13 +11,13 @@ export const toDec = (arr: Uint8Array): number => {
   return parseInt(Array.from(arr).map(v => _toBin(v, 8)).join(''), 2)
 }
 
-export async function isPng (buf: Buffer): Promise<boolean> {
+export async function isPng (buf: Deno.Buffer): Promise<boolean> {
   const pngSignature = '137 80 78 71 13 10 26 10'
   const p = new Uint8Array(8); await buf.read(p)
   return p.join(' ').toUpperCase() === pngSignature
 }
 
-export async function readIHDR (buf: Buffer): Promise<ImageInfo> {
+export async function readIHDR (buf: Deno.Buffer): Promise<ImageInfo> {
   // https://tools.ietf.org/html/rfc2083#page-15
   // Length, ChunkType
   await skip(buf, 4 + 4)
@@ -35,7 +35,7 @@ export function getCharCodes (raw: string): string {
   return raw.split('').map(c => c.charCodeAt(0)).join(' ')
 }
 
-export async function skip (buf: Buffer, bytes: number) {
+export async function skip (buf: Deno.Buffer, bytes: number) {
   const _ = new Uint8Array(bytes);
   await buf.read(_)
 }

--- a/writer.ts
+++ b/writer.ts
@@ -1,5 +1,5 @@
-import {crc} from './crc32.ts'
-import {parsePngFormat} from './reader.ts'
+import { crc } from './crc32.ts'
+import { parsePngFormat } from './reader.ts'
 const { Buffer } = Deno
 
 // Number of pixels per unit when DPI is 72
@@ -14,7 +14,7 @@ function bytes (num, byteLength): Array<number> {
 
 async function getInsertPosition(buf: Deno.Buffer): Promise<number> {
   const _buf = new Buffer(buf.bytes())
-  const {dpi} = await parsePngFormat(_buf)
+  const { dpi } = await parsePngFormat(_buf)
   // 既存のpHYsを上書きしない
   if (dpi !== undefined) return -1
   // すべて既読、つまり、"IDAT"が存在しない

--- a/writer.ts
+++ b/writer.ts
@@ -1,6 +1,6 @@
-import {Buffer} from 'deno'
 import {crc} from './crc32.ts'
 import {parsePngFormat} from './reader.ts'
+const { Buffer } = Deno
 
 // Number of pixels per unit when DPI is 72
 // Number of pixels per unit when devicePixelRatio is 1
@@ -12,7 +12,7 @@ function bytes (num, byteLength): Array<number> {
   return binArr.map(v => parseInt(v, 2))
 }
 
-async function getInsertPosition(buf: Buffer): Promise<number> {
+async function getInsertPosition(buf: Deno.Buffer): Promise<number> {
   const _buf = new Buffer(buf.bytes())
   const {dpi} = await parsePngFormat(_buf)
   // 既存のpHYsを上書きしない
@@ -43,7 +43,7 @@ function makeChunkPhys (dpi: number): Uint8Array {
   return new Uint8Array(pHYsChunk)
 }
 
-export async function writePngDpi(src: Buffer, dpi: number): Promise<Uint8Array> {
+export async function writePngDpi(src: Deno.Buffer, dpi: number): Promise<Uint8Array> {
   const insertPosition = await getInsertPosition(src)
   if (insertPosition < 0) return src.bytes()
 


### PR DESCRIPTION
https://github.com/denoland/deno/blob/master/Releases.md

`import { Buffer } from 'deno';` -> `const { Buffer } = Deno;`
  - >The major API change in this release is that instead of importing a "deno" module, there is now a global variable called Deno. This allows code that does deno-specific stuff to still operate in browsers. We will remain backward compatible with the old way of importing core functionality, but it will be removed in the near future, so please update your code. See #1748 for more details.


`buf: Buffer` -> `buf: Deno.Buffer`
  - ```
     Cannot find name 'Buffer'.
     const readChunks = async (buf: Buffer): Promise<ImageInfo> => {
    ```

## Check
```
$ rm a.png
$ deno ./examples/writer.ts --recompile --allow-read ./examples/non-retina/8d132d64902c1323ffa8ca688b2c40eb.png 72 > a.png
$ deno ./examples/reader.ts --recompile --allow-read a.png
{ width: 49, height: 42, dpi: 72 }
```

```
$ deno ./examples/reader.ts --recompile --allow-net https://i.gyazo.com/7127a0c2a987ea50dbba0ebd6455c206.png
{ width: 1102, height: 994, dpi: 144 }
```